### PR TITLE
chore(deps-dev): update Playwright to 1.61.1

### DIFF
--- a/docs/DEPENDENCY_UPGRADES.md
+++ b/docs/DEPENDENCY_UPGRADES.md
@@ -120,6 +120,17 @@ toolchain and do not use `npm audit fix --force`.
 - The current root audit backlog is limited to transitive upstream packages; no Critical
   finding remains and no force-upgrade or untested override is permitted.
 
+## 2026-08-09 Playwright Compatibility Update
+
+- The isolated browser-test dependency is updated from `@playwright/test@1.58.2` to
+  `@playwright/test@1.61.1`, with matching `playwright` and `playwright-core` lock entries.
+- `1.61.1` is the newest tested release that still installs Chromium on the required macOS
+  12.7.6 x86_64 development host. The current `1.62.1` release rejects that platform, so it
+  is intentionally deferred until the development host operating system is upgraded.
+- Local verification passed all 15 wallet-connect and 11 Web3 write-flow browser tests,
+  routing and documentation gates, the static Benefits preflight, 642 contract tests,
+  30 generator tests and 36 SDK tests. Exact-head Linux CI remains mandatory before merge.
+
 ## 2026-08-01 Root Security Patch
 
 - Hardhat was updated from `3.11.1` to `3.12.0`, which replaces vulnerable

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@nomicfoundation/hardhat-ethers-chai-matchers": "3.0.11",
         "@nomicfoundation/hardhat-mocha": "3.0.21",
         "@nomicfoundation/hardhat-verify": "3.0.21",
-        "@playwright/test": "1.58.2",
+        "@playwright/test": "1.61.1",
         "axe-core": "^4.12.1",
         "chai": "6.2.2",
         "dotenv": "^17.3.1",
@@ -1279,13 +1279,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
-      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.58.2"
+        "playwright": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -3108,13 +3108,13 @@
       "license": "ISC"
     },
     "node_modules/playwright": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.58.2"
+        "playwright-core": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -3127,9 +3127,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@nomicfoundation/hardhat-ethers-chai-matchers": "3.0.11",
     "@nomicfoundation/hardhat-mocha": "3.0.21",
     "@nomicfoundation/hardhat-verify": "3.0.21",
-    "@playwright/test": "1.58.2",
+    "@playwright/test": "1.61.1",
     "axe-core": "^4.12.1",
     "chai": "6.2.2",
     "dotenv": "^17.3.1",


### PR DESCRIPTION
## Summary
- update the exact root `@playwright/test` pin from 1.58.2 to 1.61.1
- refresh only the matching Playwright lock entries
- document the platform compatibility decision

## Compatibility decision
The registry latest, 1.62.1, was tested first but rejects Chromium installation on the required macOS 12.7.6 x86_64 development host. Version 1.61.1 successfully installs its matching Chromium 149 build and is therefore the newest verified compatible release. Ubuntu CI remains covered by `playwright install --with-deps chromium`.

## Validation
- `npm ci`
- `npm audit --audit-level=moderate` (only eight known low Ethers-v5 transitive findings without an upstream fix)
- 15 wallet-connect Playwright tests
- 11 Web3 write-flow Playwright tests
- surface routing, 35 wiki heads, Benefits documentation and Docs-CI gates
- static Benefits preflight
- Hardhat configuration gate
- 642 contract tests, 30 generator tests and 36 SDK tests
- independent read-only diff/compatibility review: no blockers

No application runtime, contract, wallet implementation, production configuration or deployment changes.