### PR TITLE
Add private-operator security audit handoff

### DIFF
--- a/docs/agent-bridge/CODEX_FINDINGS.md
+++ b/docs/agent-bridge/CODEX_FINDINGS.md
@@ -1,0 +1,10 @@
+# Codex Findings
+
+## 2026-08-13 — Public security audit handoff — OPEN
+
+- A private VLABS operator audit records unresolved public-data hygiene,
+  scanner-quality and contract-analysis work. No live secret compromise was
+  confirmed by the covered current-checkout review.
+- Obtain a bounded, no-secrets task from the operator and preserve every
+  existing governance, multisig and mainnet gate. Never publish finding details
+  or raw scanner evidence here.


### PR DESCRIPTION
## Summary\n- records a sanitized security-audit status and private-operator handoff\n- keeps detailed findings and evidence out of this repository\n- changes documentation only; no runtime, payment, deployment, IAM, or production state\n\n## Verification\n- git diff --check: PASS\n- added-line secret/privacy pattern scan: PASS\n\n## Safety\nNo raw scanner output, credential values, infrastructure identifiers, device/customer/payment data, or private evidence is included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a security audit handoff document covering unresolved data-hygiene, scanner-quality, and contract-analysis items.
  * Recorded that no live secret compromise was confirmed.
  * Documented requirements for controlled follow-up work and safeguarding sensitive findings and evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->